### PR TITLE
Fix blog like state synchronization between list and detail pages

### DIFF
--- a/backend/src/main/java/com/shop/backend/controller/BlogController.java
+++ b/backend/src/main/java/com/shop/backend/controller/BlogController.java
@@ -43,9 +43,24 @@ public class BlogController {
         return ResponseEntity.ok(posts);
     }
     
-    @GetMapping("/posts/{slug}")
-    public ResponseEntity<BlogPostDTO> getPostBySlug(@PathVariable String slug) {
-        BlogPostDTO post = blogService.getPostBySlug(slug);
+    @GetMapping("/posts/{id}")
+    public ResponseEntity<BlogPostDTO> getPostByIdOrSlug(@PathVariable String id, Authentication authentication) {
+        String userEmail = null;
+        if (authentication != null && authentication.isAuthenticated()) {
+            userEmail = getCurrentUserEmail(authentication);
+        }
+        
+        BlogPostDTO post;
+        
+        // Try to parse as Long ID first
+        try {
+            Long postId = Long.parseLong(id);
+            post = blogService.getPostById(postId, userEmail);
+        } catch (NumberFormatException e) {
+            // If not a number, treat as slug
+            post = blogService.getPostBySlug(id, userEmail);
+        }
+        
         if (post != null) {
             return ResponseEntity.ok(post);
         }
@@ -62,8 +77,12 @@ public class BlogController {
     }
     
     @GetMapping("/posts/{id}/public")
-    public ResponseEntity<BlogPostDTO> getPostPublic(@PathVariable Long id) {
-        BlogPostDTO post = blogService.getPostByIdPublic(id);
+    public ResponseEntity<BlogPostDTO> getPostPublic(@PathVariable Long id, Authentication authentication) {
+        String userEmail = null;
+        if (authentication != null && authentication.isAuthenticated()) {
+            userEmail = getCurrentUserEmail(authentication);
+        }
+        BlogPostDTO post = blogService.getPostByIdPublic(id, userEmail);
         if (post != null) {
             return ResponseEntity.ok(post);
         }

--- a/backend/src/main/java/com/shop/backend/service/BlogService.java
+++ b/backend/src/main/java/com/shop/backend/service/BlogService.java
@@ -82,27 +82,35 @@ public class BlogService {
     public Page<BlogPostDTO> getPostsByCategory(Long categoryId, Pageable pageable) {
         Page<BlogPost> posts = blogPostRepository.findByCategoryIdAndStatus(
             categoryId, BlogPost.BlogPostStatus.published, pageable);
-        return posts.map(this::convertToDTO);
+        return posts.map(post -> convertToDTO(post, null));
     }
     
     public Page<BlogPostDTO> getPostsByTag(Long tagId, Pageable pageable) {
         Page<BlogPost> posts = blogPostRepository.findByTagIdAndStatus(
             tagId, BlogPost.BlogPostStatus.published, pageable);
-        return posts.map(this::convertToDTO);
+        return posts.map(post -> convertToDTO(post, null));
     }
     
     public Page<BlogPostDTO> searchPosts(String keyword, Pageable pageable) {
         Page<BlogPost> posts = blogPostRepository.searchPosts(
             BlogPost.BlogPostStatus.published, keyword, pageable);
-        return posts.map(this::convertToDTO);
+        return posts.map(post -> convertToDTO(post, null));
     }
     
     public BlogPostDTO getPostBySlug(String slug) {
+        return getPostBySlug(slug, null);
+    }
+    
+    public BlogPostDTO getPostBySlug(String slug, String userEmail) {
         Optional<BlogPost> post = blogPostRepository.findBySlug(slug);
-        return post.map(this::convertToDTO).orElse(null);
+        return post.map(p -> convertToDTO(p, userEmail)).orElse(null);
     }
     
     public BlogPostDTO getPostById(Long id) {
+        return getPostById(id, null);
+    }
+    
+    public BlogPostDTO getPostById(Long id, String userEmail) {
         Optional<BlogPost> post = blogPostRepository.findById(id);
         if (post.isPresent()) {
             // Debug comment count
@@ -114,12 +122,16 @@ public class BlogService {
             
             // Refresh post from database after update
             post = blogPostRepository.findById(id);
-            return convertToDTO(post.get());
+            return convertToDTO(post.get(), userEmail);
         }
         return null;
     }
     
     public BlogPostDTO getPostByIdPublic(Long id) {
+        return getPostByIdPublic(id, null);
+    }
+    
+    public BlogPostDTO getPostByIdPublic(Long id, String userEmail) {
         // For public access, only return published posts
         Optional<BlogPost> post = blogPostRepository.findByIdAndStatus(id, BlogPost.BlogPostStatus.published);
         if (post.isPresent()) {
@@ -128,7 +140,7 @@ public class BlogService {
             
             // Refresh post from database after update
             post = blogPostRepository.findByIdAndStatus(id, BlogPost.BlogPostStatus.published);
-            return convertToDTO(post.get());
+            return convertToDTO(post.get(), userEmail);
         }
         return null;
     }


### PR DESCRIPTION
- Modified BlogController.getPostByIdOrSlug to handle both numeric IDs and string slugs
- Updated BlogService methods to accept userEmail parameter for proper like state detection
- Fixed getPostByIdPublic to receive authentication and pass userEmail to convertToDTO
- Ensured like status is correctly reflected on blog post detail pages
- Resolved issue where liked posts showed incorrect like state on detail page